### PR TITLE
fix(docker): dpkg version scanning

### DIFF
--- a/twigs/docker.py
+++ b/twigs/docker.py
@@ -272,7 +272,7 @@ def discover_ubuntu_from_container_image(container_fs):
             if line.startswith('Package:'):
                 pkg = line.split(':')[1].strip()
             if line.startswith('Version:'):
-                ver = line.split(':')[1].strip()
+                ver = ':'.join(line.split(':')[1:]).strip()
     return plist
 
 def discover_alpine_from_container_image(container_fs):


### PR DESCRIPTION
As per the [debian documentation](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version), the `Version` field of the package can contain colon(`:`).
For example, here's an example from my system:
```
frank@hakk:~$ cat /var/lib/dpkg/status | grep -E '^Package: .*zlib1g' -A19
Package: zlib1g
Status: install ok installed
Priority: required
Section: libs
Installed-Size: 156
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Architecture: amd64
Multi-Arch: same
Source: zlib
Version: 1:1.2.8.dfsg-2ubuntu4.3
Provides: libz1
Depends: libc6 (>= 2.14)
Breaks: libxml2 (<< 2.7.6.dfsg-2), texlive-binaries (<< 2009-12)
Conflicts: zlib1 (<= 1:1.0.4-7)
Description: compression library - runtime
 zlib is a library implementing the deflate compression method found
 in gzip and PKZIP.  This package includes the shared library.
Homepage: http://zlib.net/
Original-Maintainer: Mark Brown <broonie@debian.org>
```
To fix this, re-combine the splitted chunks that comes after the `Version:` field name.

(FYI: The `Package:` field value [cannot contain the colon](https://github.com/guillemj/dpkg/blob/68ab722604217d3ab836276acfc0ae1260b28f5f/lib/dpkg/parsehelp.c#L126), so it is left as-is.)